### PR TITLE
Raw output for newbasketitemmsg.html.twig

### DIFF
--- a/tpl/layout/header.html.twig
+++ b/tpl/layout/header.html.twig
@@ -159,5 +159,5 @@
     {% endif %}
 {% endblock %}
 
-{{ insert_new_basket_item({tpl: "widget/minibasket/newbasketitemmsg.html.twig", type: "message"}) }}
+{{ insert_new_basket_item({tpl: "widget/minibasket/newbasketitemmsg.html.twig", type: "message"})|raw }}
 {% include_dynamic "widget/minibasket/minibasketmodal.html.twig" %}


### PR DESCRIPTION
As widget/minibasket/newbasketitemmsg.html.twig contains html it has to be inserted with `raw` modifier.

Mentioned in bug entry 7548:  [https://bugs.oxid-esales.com/view.php?id=7548](https://bugs.oxid-esales.com/view.php?id=7548)