### PR TITLE
Fix for: breadcrumb can't access oDetailsProduct variable on detail page

### DIFF
--- a/tpl/widget/breadcrumb.html.twig
+++ b/tpl/widget/breadcrumb.html.twig
@@ -25,9 +25,10 @@
                                     </li>
                                 {% endfor %}
                                 {% if oView.getClassKey() == "details" %}
-                                <li class="breadcrumb-item active">
-                                    {{ oDetailsProduct.oxarticles__oxtitle.value }}
-                                </li>
+                                    {% set oDetailsProduct = oView.getProduct() %}
+                                    <li class="breadcrumb-item active">
+                                        {{ oDetailsProduct.oxarticles__oxtitle.value }}
+                                    </li>
                                 {% endif %}
                             {% endblock %}
                         </ol>


### PR DESCRIPTION
Fixes bug entry 7545
[https://bugs.oxid-esales.com/view.php?id=7545](https://bugs.oxid-esales.com/view.php?id=7545)